### PR TITLE
Implement tests of essential components of Reader RevA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Virtual environment
+venv/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/devices/stm32f0.py
+++ b/devices/stm32f0.py
@@ -29,6 +29,14 @@ class RCC(MMPeripheral):
                    'SRAMEN': 2,
                    'DMAEN': 0}
 
+    AHBRSTR_bits = {'TSCRST': 24,
+                    'IOPFRST': 22,
+                    'IOPERST': 21,
+                    'IOPDRST': 20,
+                    'IOPCRST': 19,
+                    'IOPBRST': 18,
+                    'IOPARST': 17}
+
 
 class GPIO(MMPeripheral):
     fields = [(T.uint32_t,  'MODER'),

--- a/devices/stm32f0.py
+++ b/devices/stm32f0.py
@@ -1,3 +1,9 @@
+"""Contains peripheral definitions and declarations.
+
+See STM32F0x1/STM32F0x2/STM32F0x8 reference manual RM0091.
+http://www.st.com/web/en/resource/technical/document/reference_manual/DM00031936.pdf
+"""
+
 from mempoke import MMPeripheral, T
 
 

--- a/devices/stm32f0.py
+++ b/devices/stm32f0.py
@@ -464,7 +464,7 @@ class STM32F0(object):
                       5: USART(self.APB_BUS_BASE + 0x00005000, device_memory),
                       4: USART(self.APB_BUS_BASE + 0x00004C00, device_memory),
                       3: USART(self.APB_BUS_BASE + 0x00004800, device_memory),
-                      2: USART(self.APB_BUS_BASE + 0x00004000, device_memory)}
+                      2: USART(self.APB_BUS_BASE + 0x00004400, device_memory)}
         self.ADC = ADC(self.APB_BUS_BASE + 0x00012400, device_memory)
         self.DAC = DAC(self.APB_BUS_BASE + 0x00007800, device_memory)
         self.USB = USB(self.APB_BUS_BASE + 0x00005C00, device_memory)

--- a/devices/stm32f0.py
+++ b/devices/stm32f0.py
@@ -77,6 +77,32 @@ class RCC(MMPeripheral):
                      'TIM3RST': 1,
                      'TIM2RST': 0}
 
+    APB2ENR_bits = {'DBGMCUEN': 22,
+                    'TIM17EN': 18,
+                    'TIM16EN': 17,
+                    'TIM15EN': 16,
+                    'USART1EN': 14,
+                    'SPI1EN': 12,
+                    'TIM1EN': 11,
+                    'ADCEN': 9,
+                    'USART8EN': 7,
+                    'USART7EN': 6,
+                    'USART6EN': 5,
+                    'SYSCFGCOMPEN': 0}
+    
+    APB2RSTR_bits = {'DBGMCURST': 22,
+                     'TIM17RST': 18,
+                     'TIM16RST': 17,
+                     'TIM15RST': 16,
+                     'USART1RST': 14,
+                     'SPI1RST': 12,
+                     'TIM1RST': 11,
+                     'ADCRST': 9,
+                     'USART8RST': 7,
+                     'USART7RST': 6,
+                     'USART6RST': 5,
+                     'SYSCFGRST': 0}
+
 
 class GPIO(MMPeripheral):
     fields = [(T.uint32_t,  'MODER'),
@@ -333,7 +359,12 @@ class SPI(MMPeripheral):
     fields = [(T.uint32_t,  'CR1'),
               (T.uint32_t,  'CR2'),
               (T.uint32_t,  'SR'),
-              (T.uint16_t,  'DR'),
+              # This register should be 16 bit. However, when used in 8 bit mode, writing 8 bit value
+              # will cause 2 bytes to be transferred (our byte and NULL byte). This is a dirty workaround, since
+              # this peripheral will most commonly be used only in the 8-bit mode. Eventually better solution will
+              # be implemented.
+              (T.uint8_t,  'DR'),
+              (T.uint8_t,  None),
               (T.uint16_t,  None),
               (T.uint16_t,  'CRCPR'),
               (T.uint16_t,  None),
@@ -508,4 +539,5 @@ class STM32F0(object):
         self.ADC = ADC(self.APB_BUS_BASE + 0x00012400, device_memory)
         self.DAC = DAC(self.APB_BUS_BASE + 0x00007800, device_memory)
         self.USB = USB(self.APB_BUS_BASE + 0x00005C00, device_memory)
-        self.SPI = {2: SPI(self.APB_BUS_BASE + 0x00003800, device_memory)}
+        self.SPI = {2: SPI(self.APB_BUS_BASE + 0x00003800, device_memory),
+                    1: SPI(self.APB_BUS_BASE + 0x00013000, device_memory)}

--- a/devices/stm32f0.py
+++ b/devices/stm32f0.py
@@ -50,8 +50,8 @@ class GPIO(MMPeripheral):
               (T.uint16_t,  None),
               (T.uint32_t,  'BSRR'),
               (T.uint32_t,  'LCKR'),
-              (T.uint32_t,  'AFR0'),
-              (T.uint32_t,  'AFR1'),
+              (T.uint32_t,  'AFRL'),
+              (T.uint32_t,  'AFRH'),
               (T.uint16_t,  'BRR'),
               (T.uint16_t,  None)]
 

--- a/devices/stm32f0.py
+++ b/devices/stm32f0.py
@@ -37,6 +37,46 @@ class RCC(MMPeripheral):
                     'IOPBRST': 18,
                     'IOPARST': 17}
 
+    APB1ENR_bits = {'CECEN': 30,
+                    'DACEN': 29,
+                    'PWREN': 28,
+                    'CRSEN': 27,
+                    'CANEN': 25,
+                    'USBEN': 23,
+                    'I2C2EN': 22,
+                    'I2C1EN': 21,
+                    'USART5EN': 20,
+                    'USART4EN': 19,
+                    'USART3EN': 18,
+                    'USART2EN': 17,
+                    'SPI2EN': 14,
+                    'WWDGEN': 11,
+                    'TIM14EN': 8,
+                    'TIM7EN': 5,
+                    'TIM6EN': 4,
+                    'TIM3EN': 1,
+                    'TIM2EN': 0}
+
+    APB1RSTR_bits = {'CECRST': 30,
+                     'DACRST': 29,
+                     'PWRRST': 28,
+                     'CRSRST': 27,
+                     'CANRST': 25,
+                     'USBRST': 23,
+                     'I2C2RST': 22,
+                     'I2C1RST': 21,
+                     'USART5RST': 20,
+                     'USART4RST': 19,
+                     'USART3RST': 18,
+                     'USART2RST': 17,
+                     'SPI2RST': 14,
+                     'WWDGRST': 11,
+                     'TIM14RST': 8,
+                     'TIM7RST': 5,
+                     'TIM6RST': 4,
+                     'TIM3RST': 1,
+                     'TIM2RST': 0}
+
 
 class GPIO(MMPeripheral):
     fields = [(T.uint32_t,  'MODER'),

--- a/interactive
+++ b/interactive
@@ -1,0 +1,64 @@
+#!/bin/sh
+
+if [ -z "$1" ] || [ -z "$2" ] || [ ! -f "devices/$1.py" ]; then
+    echo 'Opens interactive Python console inside gdb with slave'
+    echo 'device already set-up.'
+    echo 'Usage: ./interactive device_file device_object [gdb_server_port]'
+    echo
+    echo 'device_file may be:'
+    for device in `ls devices/`; do
+        if [[ ! $device == __* ]] && [[ $device == *.py ]]; then
+            echo -e "\t${device%.*}"
+        fi
+    done
+    echo
+    echo 'Example: ./interactive stm32f0 STM32F0'
+    exit 1
+fi
+
+GDB_PORT='4242'
+
+if [ ! -z "$3" ]; then
+    GDB_PORT=$3
+fi
+
+PYTHON_VERSION=$(python2 --version 2>&1)
+
+if [[ ! $PYTHON_VERSION == Python\ 2.7* ]]; then
+    echo "Python 2.7 is required, your version is $PYTHON_VERSION"
+    exit 2
+fi
+
+# Python launched from GDB won't allow importing modules from the current working dir
+# and ignores anything which may have been added to the `sys.path` as a result of using virtualenv.
+# This is a (ugly, I am so sorry...) hack which puts those two things back
+# to sys.path
+VENV_APPEND=""
+if [ ! -z "$VIRTUAL_ENV" ]; then
+    VENV_APPEND="sys.path.append('$VIRTUAL_ENV/lib/python2.7/site-packages')"
+fi
+
+PYTHON_HACK="python
+import sys
+import os
+sys.path.append(os.getcwd())
+$VENV_APPEND"
+
+# This part sets up device object as a wrapper around the real device.
+PYTHON_SETUP="python
+import mempoke
+from devices.$1 import $2
+dev = $2(mempoke.DeviceMemory())"
+
+# And this opens the interactive console.
+PYTHON_INTERACTIVE="python
+import code
+vars = globals()
+vars.update(locals())
+shell = code.InteractiveConsole(vars)
+print 'Device is available as variable \'dev\'.'
+shell.interact()"
+
+REMOTE_DEBUG="target extended :$GDB_PORT"
+
+arm-none-eabi-gdb -batch -ex "$REMOTE_DEBUG" -ex "$PYTHON_HACK" -ex "$PYTHON_SETUP" -ex "$PYTHON_INTERACTIVE"

--- a/interactive
+++ b/interactive
@@ -50,15 +50,6 @@ import mempoke
 from devices.$1 import $2
 dev = $2(mempoke.DeviceMemory())"
 
-# And this opens the interactive console.
-PYTHON_INTERACTIVE="python
-import code
-vars = globals()
-vars.update(locals())
-shell = code.InteractiveConsole(vars)
-print 'Device is available as variable \'dev\'.'
-shell.interact()"
-
 REMOTE_DEBUG="target extended :$GDB_PORT"
 
-arm-none-eabi-gdb -batch -ex "$REMOTE_DEBUG" -ex "$PYTHON_HACK" -ex "$PYTHON_SETUP" -ex "$PYTHON_INTERACTIVE"
+arm-none-eabi-gdb -batch -ex "$REMOTE_DEBUG" -ex "$PYTHON_HACK" -ex "$PYTHON_SETUP" -x interactive_utils.py

--- a/interactive
+++ b/interactive
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ -z "$1" ] || [ -z "$2" ] || [ ! -f "devices/$1.py" ]; then
     echo 'Opens interactive Python console inside gdb with slave'
@@ -6,9 +6,9 @@ if [ -z "$1" ] || [ -z "$2" ] || [ ! -f "devices/$1.py" ]; then
     echo 'Usage: ./interactive device_file device_object [gdb_server_port]'
     echo
     echo 'device_file may be:'
-    for device in `ls devices/`; do
-        if [[ ! $device == __* ]] && [[ $device == *.py ]]; then
-            echo -e "\t${device%.*}"
+    for device_file in `ls devices/`; do
+        if [[ ! $device_file == __* ]] && [[ $device_file == *.py ]]; then
+            echo -e "\t${device_file%.*}"
         fi
     done
     echo
@@ -16,11 +16,7 @@ if [ -z "$1" ] || [ -z "$2" ] || [ ! -f "devices/$1.py" ]; then
     exit 1
 fi
 
-GDB_PORT='4242'
-
-if [ ! -z "$3" ]; then
-    GDB_PORT=$3
-fi
+GDB_PORT=${3:-4242}
 
 PYTHON_VERSION=$(python2 --version 2>&1)
 
@@ -48,6 +44,7 @@ $VENV_APPEND"
 PYTHON_SETUP="python
 import mempoke
 from devices.$1 import $2
+print 'Device is available as variable \'dev\'.'
 dev = $2(mempoke.DeviceMemory())"
 
 REMOTE_DEBUG="target extended :$GDB_PORT"

--- a/interactive_utils.py
+++ b/interactive_utils.py
@@ -1,0 +1,54 @@
+import code
+
+
+def reg(number, flags_dict=None):
+    print hex(number)
+    print ''
+
+    bits = [int(bit) for bit in bin(number)[2:]]
+    flags = [(bit, '') for bit in bits]
+    if len(flags) % 4 != 0:
+        flags = ([(0, '')]*(4 - (len(flags) % 4))) + flags
+
+    if flags_dict is not None:
+        for flag, bit in flags_dict.items():
+            try:
+                if (len(flags) - bit - 1) >= 0:
+                    val = flags[len(flags) - bit - 1][0]
+                    flags[len(flags) - bit - 1] = (val, flag)
+            except IndexError:
+                pass
+
+    flags_to_print = []
+    max_length = 0
+
+    for i, flag in enumerate(flags):
+        bit_num = len(flags) - i - 1
+        if len(flags_to_print) < (i/4)+1:
+            flags_to_print.append([])
+        flag_str = '[{}] ({}): {}'.format(bit_num, flag[1], flag[0])
+        flags_to_print[i/4].append(flag_str)
+        max_length = max(max_length, len(flag_str))
+
+    space = max_length + 2
+
+    print '0x ', ''.join(['{}{}'.format(x, ' '*(space-len(x))) for x in hex(number)[2:]])
+    print '0b ', ''.join(['{}{}'.format(x, ' '*(space-len(x)))
+                          for x in [''.join(str(f[0])
+                                            for f in flags[y:y+4])
+                                    for y in range(0, len(flags), 4)]])
+
+    print ''
+
+    for i in range(0, 4):
+        print '   ',
+        for line in flags_to_print:
+            print line[i] + (' '*(space-len(line[i])-1)),
+        print ''
+
+
+vars = globals()
+vars.update(locals())
+shell = code.InteractiveConsole(vars)
+print 'Device is available as variable \'dev\'.'
+shell.interact()

--- a/interactive_utils.py
+++ b/interactive_utils.py
@@ -1,5 +1,6 @@
 import code
 
+
 # TODO this will be rewritten as a part of the new register interface
 def reg(number, flags_dict=None):
     print hex(number)
@@ -26,7 +27,8 @@ def reg(number, flags_dict=None):
         bit_num = len(flags) - i - 1
         if len(flags_to_print) < (i/4)+1:
             flags_to_print.append([])
-        flag_str = '[{bit}] ({flag_name}): {value}'.format(bit=bit_num, flag_name=flag[1], value=flag[0])
+        flag_str = '[{bit}] ({flag_name}): {value}'.format(bit=bit_num, flag_name=flag[1],
+                                                           value=flag[0])
         flags_to_print[i/4].append(flag_str)
         max_length = max(max_length, len(flag_str))
 
@@ -50,5 +52,4 @@ def reg(number, flags_dict=None):
 vars = globals()
 vars.update(locals())
 shell = code.InteractiveConsole(vars)
-print 'Device is available as variable \'dev\'.'
 shell.interact()

--- a/interactive_utils.py
+++ b/interactive_utils.py
@@ -1,6 +1,6 @@
 import code
 
-
+# TODO this will be rewritten as a part of the new register interface
 def reg(number, flags_dict=None):
     print hex(number)
     print ''
@@ -26,7 +26,7 @@ def reg(number, flags_dict=None):
         bit_num = len(flags) - i - 1
         if len(flags_to_print) < (i/4)+1:
             flags_to_print.append([])
-        flag_str = '[{}] ({}): {}'.format(bit_num, flag[1], flag[0])
+        flag_str = '[{bit}] ({flag_name}): {value}'.format(bit=bit_num, flag_name=flag[1], value=flag[0])
         flags_to_print[i/4].append(flag_str)
         max_length = max(max_length, len(flag_str))
 

--- a/mempoke.py
+++ b/mempoke.py
@@ -39,7 +39,9 @@ class MMPeripheral(object):
     OFFSET = 1
 
     def __init__(self, address, memory):
-        self.compiled_fields = {}
+        # Our __setattr__ depends on this being set, bypass it.|
+        # Do _not_ set any instance attributes before this line.
+        super().__setattr__('compiled_fields', {})
         self.memory = memory
         self.address = address
         offset = 0
@@ -57,7 +59,7 @@ class MMPeripheral(object):
             raise ValueError('This peripheral does not contain register ' + name)
 
     def __setattr__(self, name, value):
-        if name != 'compiled_fields' and name in self.compiled_fields:
+        if name in self.compiled_fields:
             self.memory.write(self.compiled_fields[name][MMPeripheral.TYPE],
                               self.address + self.compiled_fields[name][MMPeripheral.OFFSET],
                               value)

--- a/mempoke.py
+++ b/mempoke.py
@@ -38,9 +38,8 @@ class MMPeripheral(object):
     TYPE = 0
     OFFSET = 1
 
-    compiled_fields = {}
-
     def __init__(self, address, memory):
+        self.compiled_fields = {}
         self.memory = memory
         self.address = address
         offset = 0
@@ -58,7 +57,7 @@ class MMPeripheral(object):
             raise ValueError('This peripheral does not contain register ' + name)
 
     def __setattr__(self, name, value):
-        if name in self.compiled_fields:
+        if name != 'compiled_fields' and name in self.compiled_fields:
             self.memory.write(self.compiled_fields[name][MMPeripheral.TYPE],
                               self.address + self.compiled_fields[name][MMPeripheral.OFFSET],
                               value)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pyserial==3.0.1
+wheel==0.24.0

--- a/test_sequencer.py
+++ b/test_sequencer.py
@@ -43,7 +43,7 @@ def run(tests):
             print '------------------------------------'
 
 
-def ask(question):
+def ask_YN(question):
     answer = None
     while True:
         print '\t\t-? {0} [Y/N]'.format(question),
@@ -53,7 +53,7 @@ def ask(question):
     return answer.strip().upper() == 'Y'
 
 
-def request_info(question):
+def ask(question):
     print '\t\t-? {0}:'.format(question),
     return raw_input()
 

--- a/test_sequencer.py
+++ b/test_sequencer.py
@@ -50,3 +50,12 @@ def ask(question):
         if answer.strip().upper() in ['Y', 'N']:
             break
     return answer.strip().upper() == 'Y'
+
+
+def askForString(question):
+    print '\t\t-? {0}:'.format(question),
+    return raw_input()
+
+
+def say(something):
+    print '\t\t- {0}'.format(something)

--- a/test_sequencer.py
+++ b/test_sequencer.py
@@ -22,8 +22,8 @@ def run(tests):
     ok = []
     fail = []
     for number, test in enumerate(tests):
-        print '\t-> [{num}/{total}] {name} ({doc})'.format(num=number, total=len(tests),
-                                                           name=test.__name__, doc=test.__doc__)
+        print '\t-> [{num}/{total}] {name} ({doc})'.format(num=number+1, total=len(tests),
+                                                           name=test.__name__, doc=test.__doc__.splitlines()[0])
         error = test()
         if error is None:
             ok.append((number, test))
@@ -36,10 +36,11 @@ def run(tests):
     print '\tFAILED: {}'.format(len(fail))
     if len(fail) > 0:
         print ''
-        print '--- Failures ---'
+        print '------------- FAILURES -------------'
         for number, test, error in fail:
-            print 'Test {number} - {name} ({doc})\n{err}'.format(number=number, name=test.__name__,
+            print '\nTest {number} - {name}\n{doc}\n{err}'.format(number=number+1, name=test.__name__,
                                                                  doc=test.__doc__, err=error)
+            print '------------------------------------'
 
 
 def ask(question):
@@ -52,7 +53,7 @@ def ask(question):
     return answer.strip().upper() == 'Y'
 
 
-def askForString(question):
+def request_info(question):
     print '\t\t-? {0}:'.format(question),
     return raw_input()
 

--- a/tests/reader-revA-test.py
+++ b/tests/reader-revA-test.py
@@ -7,7 +7,8 @@ and the device is deployed
 """
 
 import mempoke
-from test_sequencer import run, ask
+import serial
+from test_sequencer import run, ask, askForString, say
 from devices.stm32f0 import STM32F0
 
 
@@ -27,9 +28,15 @@ def reset_peripherals():
         dev.RCC.AHBRSTR |= (1 << dev.RCC.AHBRSTR_bits["IOP" + i + "RST"])
         dev.RCC.AHBRSTR &= ~(1 << dev.RCC.AHBRSTR_bits["IOP" + i + "RST"])
 
+    for bit in dev.RCC.APB1RSTR_bits.values():
+        dev.RCC.APB1RSTR |= (1 << bit)
+        dev.RCC.APB1RSTR &= ~(1 << bit)
+
 
 def led1():
     """Tests green LED1"""
+    reset_peripherals()
+
     turn_on_led('B', 1)
     error = None
     if not ask('Is LED1 green?'):
@@ -40,6 +47,8 @@ def led1():
 
 def led2():
     """Tests green LED2"""
+    reset_peripherals()
+
     turn_on_led('A', 8)
     error = None
     if not ask('Is LED2 green?'):
@@ -50,6 +59,8 @@ def led2():
 
 def test_reader():
     """Tests communication with the RFID module"""
+    reset_peripherals()
+
     # Enable port A GPIO for SPI usage
     dev.RCC.AHBENR |= (1 << dev.RCC.AHBRSTR_bits["IOPAEN"])
     # Set pins used by SPI1 to 'Alternate' mode
@@ -77,18 +88,85 @@ def test_reader():
 
 def usart_transmit():
     """Tests functionality of the RS232 interface direction reader -> controller."""
+    # This is undoable in the current board revision. USART 2 Tx shares pin with SWCLK, we would
+    # loose the debug link
     pass
 
 
 def usart_receive():
     """Tests functionality of the RS232 interface direction reader <- controller."""
-    # Set-up GPIO Rx pin (GPIOA 15?) as alternate
-    # Set GPIOA 15 AF-1
-    # Enable clock to USART 2
-    # Set baud rate: clock in debug config is 8MHz => 833
-    # Enable receiver and enable USART 2
-    # Check RDR
+    reset_peripherals()
 
-tests = [usart_transmit]
+    port_name = askForString("Serial port name to use")
+    port = serial.Serial(port_name, 9600)
+    say("pySerial is using port " + port.name)
+
+    # Enable GPIO A (USART Rx is using GPIOA 15)
+    dev.RCC.AHBENR |= (1 << dev.RCC.AHBENR_bits["IOPAEN"])
+    # Alternate function 1 for GPIOA 15 (USART 2 Rx)
+    dev.GPIO['A'].MODER |= (dev.GPIO['A'].MODE_bits["ALT"] << 15*2)
+    dev.GPIO['A'].AFRH |= (1 << 28)
+    # Enable clock to USART 2
+    dev.RCC.APB1ENR |= (1 << dev.RCC.APB1ENR_bits["USART2EN"])
+    # Set baud rate: clock in debug config is 8MHz => 833
+    dev.USART[2].BRR = 833
+    # Enable receiver and enable USART 2
+    dev.USART[2].CR1 |= (1 << dev.USART[2].CR1_bits["RE"]) | (1 << dev.USART[2].CR1_bits["UE"])
+
+    # Check 'Receiver Enable Acknowledge'
+    if not dev.USART[2].ISR & (1 << dev.USART[2].ISR_bits["REACK"]):
+        reset_peripherals()
+        return "Error enabling USART 2 receiver!"
+
+    # Check for possible Rx overflow due to previous unintended transmissions
+    if dev.USART[2].ISR & (1 << dev.USART[2].ISR_bits["ORE"]):
+        dev.USART[2].ICR |= (1 << dev.USART[2].ICR_bits["ORECF"])
+
+    # Empty the Rx buffer (limit: 30 times)
+    for i in range(0, 30):
+        if dev.USART[2].ISR & dev.USART[2].ISR_bits["RXNE"]:
+            dev.USART[2].RDR
+        else:
+            break
+
+    if dev.USART[2].ISR & dev.USART[2].ISR_bits["RXNE"]:
+        reset_peripherals()
+        return "USART is receiving something, we are not transmitting. Noise?"
+
+    # Clear possible leftover error flags
+    dev.USART[2].ICR |= (1 << dev.USART[2].ICR_bits["PECF"]) | (1 << dev.USART[2].ICR_bits["FECF"])
+
+    # Check whether we have idle line and are ready to receive
+    if not dev.USART[2].ISR & (1 << dev.USART[2].ISR_bits["IDLE"]):
+        reset_peripherals()
+        return "USART is not idle, but we are not transmitting. Dry joint?"
+
+    string = "DEADLOCK"
+
+    for i, letter in enumerate(string):
+        # Transmit it
+        port.write(letter)
+        port.flush()
+
+        # Wait for reception
+        for i in range(0, 10):
+            if dev.USART[2].ISR & (1 << dev.USART[2].ISR_bits["RXNE"]):
+                break
+
+        # Check reception
+        if dev.USART[2].ISR & (1 << dev.USART[2].ISR_bits["RXNE"]):
+            if dev.USART[2].RDR == ord(letter):
+                continue
+            else:
+                reset_peripherals()
+                return "USART received something else than what we sent"
+        else:
+            reset_peripherals()
+            return "USART has not received letter " + str(i) + " (" + letter + ")"
+
+    # All done
+    reset_peripherals()
+
+tests = [usart_receive]
 # tests = [test_reader, led1, led2]
 run(tests)

--- a/tests/reader-revA-test.py
+++ b/tests/reader-revA-test.py
@@ -47,5 +47,34 @@ def led2():
     reset_peripherals()
     return error
 
-tests = [led1, led2]
+
+def test_reader():
+    """Tests communication with the RFID module"""
+    # Enable port A GPIO for SPI usage
+    dev.RCC.AHBENR |= (1 << dev.RCC.AHBRSTR_bits["IOPAEN"])
+    # Set pins used by SPI1 to 'Alternate' mode
+    for pin in [5, 6, 7, 1]:
+        dev.GPIO['A'].MODER |= (1 << dev.GPIO['A'].MODE_bits["ALT"] << pin*2)
+
+    # Use software slave management
+    dev.SPI[1].CR1 |= (1 << dev.SPI[1].CR1_bits["SSM"])
+    # Slowest comm speed (safest option) (0x111 to BR[2:0])
+    dev.SPI[1].CR1 |= (0x111 << 3)
+    # We are the master
+    dev.SPI[1].CR1 |= (1 << dev.SPI[1].CR1_bits["MSTR"])
+    # Clock phase and clock polarity is left on default
+
+    # 8-bit transfer data size
+    dev.SPI[1].CR2 |= (0x0111 << 8)
+    # Enable control of Slave Select pin
+    dev.SPI[1].CR2 |= (1 << dev.SPI[1].CR2_bits["SSOE"])
+    # Generate RX-Not-empty event when 8 bits were received
+    dev.SPI[1].CR2 |= (1 << dev.SPI[1].CR2_bits["FRXTH"])
+
+    # Enable the SPI
+    dev.SPI[1].CR1 |= (1 << dev.SPI[1].CR1_bits["SPE"])
+
+
+tests = [test_reader]
+# tests = [test_reader, led1, led2]
 run(tests)

--- a/tests/reader-revA-test.py
+++ b/tests/reader-revA-test.py
@@ -1,0 +1,51 @@
+"""Tests for the revA circuit board of the 'reader'.
+
+These tests will test the expected functionality of 'reader-revA'
+(https://github.com/fmfi-svt-deadlock/reader-hw/releases/tag/revA).
+They are intended to be run once on new boards before the FW is loaded
+and the device is deployed
+"""
+
+import mempoke
+from test_sequencer import run, ask
+from devices.stm32f0 import STM32F0
+
+
+dev = STM32F0(mempoke.DeviceMemory())
+
+
+def turn_on_led(port, pin):
+    """Helper function for testing LEDs"""
+    dev.RCC.AHBENR |= (1 << dev.RCC.AHBENR_bits["IOP" + port + "EN"])
+    dev.GPIO[port].MODER |= (dev.GPIO[port].MODE_bits["OUTPUT"] << pin*2)
+    dev.GPIO[port].ODR |= (1 << pin)
+
+
+def reset_peripherals():
+    """Resets used peripherals, teardown function"""
+    for i in ['A', 'B', 'C', 'D', 'E', 'F']:
+        dev.RCC.AHBRSTR |= (1 << dev.RCC.AHBRSTR_bits["IOP" + i + "RST"])
+        dev.RCC.AHBRSTR &= ~(1 << dev.RCC.AHBRSTR_bits["IOP" + i + "RST"])
+
+
+def led1():
+    """Tests green LED1"""
+    turn_on_led('B', 1)
+    error = None
+    if not ask('Is LED1 green?'):
+        error = 'Green LED1 problem'
+    reset_peripherals()
+    return error
+
+
+def led2():
+    """Tests green LED2"""
+    turn_on_led('A', 8)
+    error = None
+    if not ask('Is LED2 green?'):
+        error = 'Green LED2 problem'
+    reset_peripherals()
+    return error
+
+tests = [led1, led2]
+run(tests)

--- a/tests/reader-revA-test.py
+++ b/tests/reader-revA-test.py
@@ -75,6 +75,20 @@ def test_reader():
     dev.SPI[1].CR1 |= (1 << dev.SPI[1].CR1_bits["SPE"])
 
 
-tests = [test_reader]
+def usart_transmit():
+    """Tests functionality of the RS232 interface direction reader -> controller."""
+    pass
+
+
+def usart_receive():
+    """Tests functionality of the RS232 interface direction reader <- controller."""
+    # Set-up GPIO Rx pin (GPIOA 15?) as alternate
+    # Set GPIOA 15 AF-1
+    # Enable clock to USART 2
+    # Set baud rate: clock in debug config is 8MHz => 833
+    # Enable receiver and enable USART 2
+    # Check RDR
+
+tests = [usart_transmit]
 # tests = [test_reader, led1, led2]
 run(tests)

--- a/tests/reader-revA-test.py
+++ b/tests/reader-revA-test.py
@@ -143,7 +143,7 @@ def usart_receive():
 
     string = "DEADLOCK"
 
-    for i, letter in enumerate(string):
+    for letter_num, letter in enumerate(string):
         # Transmit it
         port.write(letter)
         port.flush()
@@ -162,7 +162,7 @@ def usart_receive():
                 return "USART received something else than what we sent"
         else:
             reset_peripherals()
-            return "USART has not received letter " + str(i) + " (" + letter + ")"
+            return "USART has not received letter " + str(letter_num) + " (" + letter + ")"
 
     # All done
     reset_peripherals()


### PR DESCRIPTION
- Implement tests for LEDs, USART and RFID module
- Add 'interactive' mode (for messing around with registers directly)
- Fix several errors in stm32f0 periph definitions and declarations

Many things are still a **TODO**:
- Rewrite interface for access to the MCU registers to something more useful
- Do something about 'interactive' mode: clean up the startup script
  - Getting autocompletion to work would be **really** nice... (gdb disables python's readline module)
- Avoid code duplicity in 'execute' and 'interactive' startup scripts
- Add remaining tests for Reader RevA:
  - Speaker
  - Power supply measurement
  - USB

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/fmfi-svt-deadlock/hw-testing/5)

<!-- Reviewable:end -->
